### PR TITLE
authorize to write shirakiya/homebrew-alug

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,4 +20,4 @@ jobs:
           args: release --rm-dist
           key: ${{ secrets.YOUR_PRIVATE_KEY }}
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.ACCESS_TOKEN }}


### PR DESCRIPTION
fix https://github.com/shirakiya/alug/runs/60927129
goreleaser cannot commit due to being not authorized.