### PR TITLE
update golangci-lint to 1.33.0

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -42,7 +42,7 @@ jobs:
             ${{ runner.os }}-go-
             ${{ runner.os }}-
       - name: Install golangci-lint
-        run: curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(go env GOPATH)/bin v1.32.0
+        run: curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(go env GOPATH)/bin v1.33.0
       - name: Workaround https://github.com/golangci/golangci-lint/issues/825
         run: go install ./...
       - name: Go lint

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@ FROM golang:1.15.3
 WORKDIR /opt/alug
 
 RUN curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | \
-  sh -s -- -b $(go env GOPATH)/bin v1.32.0
+  sh -s -- -b $(go env GOPATH)/bin v1.33.0
 
 COPY go.mod .
 COPY go.sum .


### PR DESCRIPTION
ref. https://github.com/golangci/golangci-lint/releases/tag/v1.33.0